### PR TITLE
fix MAX_SIZE env var assignment

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -9,7 +9,7 @@ const KUBE_MODEL_PORT = process.env.REACT_APP_KUBE_MODEL_PORT || ''
 const LOCAL_MODEL_PORT = process.env.REACT_APP_LOCAL_MODEL_PORT || 5000
 const DEPLOY_TYPE = process.env.REACT_APP_DEPLOY_TYPE || ''
 
-export const MAX_SIZE = process.env.REACT_APP_DEPLOY_TYPE || 513
+export const MAX_SIZE = process.env.REACT_APP_MAX_SIZE || 513
 
 export const OBJ_LIST = ['background', 'airplane', 'bicycle', 'bird', 'boat', 
 'bottle', 'bus', 'car', 'cat', 'chair', 'cow', 'dining table', 


### PR DESCRIPTION
this change fixes an incorrect variable assignment error that surfaces only when the app is deployed to a kubernetes cluster.